### PR TITLE
Add support for 'eula' metadata tag

### DIFF
--- a/Slingshot.Api/ng/Scripts/app.js
+++ b/Slingshot.Api/ng/Scripts/app.js
@@ -284,6 +284,17 @@ angular.module('formApp', ['ngAnimate', 'ui.router'])
                 setDefaultRg(sub);
             }
 
+            // Pull out EULA metadata if available. Require http* and sanitize
+
+            $scope.formData.eula = null;
+            var metadata = result.data.template.metadata;
+            if (metadata && metadata["eula"]) {
+                var eula = encodeURI(metadata["eula"].trim());
+                if (eula.indexOf('http') === 0) {
+                    $scope.formData.eula = eula;
+                }
+            }
+
             // Pull out template parameters to show on UI
             $scope.formData.params = [];
             $scope.formData.repoParamFound = false;

--- a/Slingshot.Api/ng/Scripts/app.js
+++ b/Slingshot.Api/ng/Scripts/app.js
@@ -285,7 +285,6 @@ angular.module('formApp', ['ngAnimate', 'ui.router'])
             }
 
             // Pull out EULA metadata if available. Require http* and sanitize
-
             $scope.formData.eula = null;
             var metadata = result.data.template.metadata;
             if (metadata && metadata["eula"]) {

--- a/Slingshot.Api/ng/Views/form-setup.html
+++ b/Slingshot.Api/ng/Views/form-setup.html
@@ -6,6 +6,10 @@
     <div class="text-primary header-label">
         Branch - <span class="text-info" ng-attr-title="{{formData.branch}}">{{formData.branch}}</span>
     </div>
+
+    <div ng-show="formData.eula" class="text-primary header-label">
+        EULA - <span class="text-info" ng-attr-title="{{formData.eula}}"><a href="{{formData.eula}}" target="_blank">{{formData.eula}}</a></span>
+    </div>
 </div>
 
 <div ng-show="!formData.params">


### PR DESCRIPTION
@davidebbo this change adds support for a top-level "eula" metadata tag as part of the template.

A template author may provide an `http`/`https` link to an optional EULA: 

````json

{
  "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
  "contentVersion": "1.0.0.0",
  "metadata": {
    "eula": "https://site.com/terms/example-eula"
  },
  "parameters": {},
  "variables": {},
  "resources": {}
}
````

If present, the EULA link shows up below the `Branch` info, and is a hyper-link using default project styling:

![image](https://cloud.githubusercontent.com/assets/833774/7355618/ed7e6ef2-ecd7-11e4-9d42-3e38dd98525c.png)

Find test repos here: https://github.com/thauburger/azure-rm-tools/tree/master/metadata