### PR TITLE
Target .NET 4.7 for TLS 1.2 outbound

### DIFF
--- a/Slingshot.Api/Web.config
+++ b/Slingshot.Api/Web.config
@@ -5,8 +5,8 @@
   -->
 <configuration>
   <system.web>
-    <compilation debug="true" targetFramework="4.5" />
-    <httpRuntime targetFramework="4.5" />
+    <compilation debug="true" targetFramework="4.7" />
+    <httpRuntime targetFramework="4.7" />
     <authentication mode="None" />
     <httpModules>
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Extensibility.Web.RequestTracking.WebRequestTrackingModule, Microsoft.ApplicationInsights.Extensibility.Web" />


### PR DESCRIPTION
Ref GitHub removal of TLS 1.0 & 1.1 - https://githubengineering.com/crypto-removal-notice/
Fixes https://github.com/projectkudu/slingshot/issues/86

**-UNTESTED-** I simply retargeted the framework in Web.config.